### PR TITLE
Add states:DescribeStateMachine to datadogs perms

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -119,6 +119,7 @@ resource "aws_iam_policy" "datadog-core" {
         "sns:Publish",
         "sqs:ListQueues",
         "states:ListStateMachines",
+        "states:DescribeStateMachine",
         "support:*",
         "tag:GetResources",
         "tag:GetTagKeys",


### PR DESCRIPTION
Adding `states:DescribeStateMachine` to Datadog permissions to alleviate errors 