### PR TITLE
Simplify the resource policy of the lambda

### DIFF
--- a/logs_monitoring_cloudwatch_log.tf
+++ b/logs_monitoring_cloudwatch_log.tf
@@ -8,10 +8,9 @@ resource "aws_cloudwatch_log_subscription_filter" "test_lambdafunction_logfilter
 }
 
 resource "aws_lambda_permission" "allow_cloudwatch_logs_to_call_dd_lambda_handler" {
-  count         = length(var.cloudwatch_log_groups)
-  statement_id  = "${replace(var.cloudwatch_log_groups[count.index], "/", "_")}-AllowExecutionFromCloudWatchLogs"
+  statement_id  = "${var.aws_account_id}-AllowExecutionFromCloudWatchLogs"
   action        = "lambda:InvokeFunction"
   function_name = aws_cloudformation_stack.datadog-forwarder.outputs.DatadogForwarderArn
   principal     = "logs.${var.aws_region}.amazonaws.com"
-  source_arn    = "arn:aws:logs:${var.aws_region}:${var.aws_account_id}:log-group:${var.cloudwatch_log_groups[count.index]}:*"
+  source_arn    = "arn:aws:logs:${var.aws_region}:${var.aws_account_id}:log-group:*"
 }


### PR DESCRIPTION
The current method will loop through all cloud watch log groups giving them `*` access, this causes issues when we have very many functions, since there is an artificial limit (20480) of the resource policy text. 

This change simplifies the permission step, granting the same permissions it would have originally (since we load _all_ log groups, minus the ones with more than 65 chars) without bloating the resource policy. 