### PR TITLE
making bucket name lowercase

### DIFF
--- a/logs_monitoring_elb.tf
+++ b/logs_monitoring_elb.tf
@@ -22,7 +22,7 @@ resource "aws_s3_bucket_notification" "elblog-notification-dd-log" {
 data "aws_elb_service_account" "main" {}
 
 locals {
-  elb_logs_s3_bucket = "${var.elb_logs_bucket_prefix}-${var.namespace}-${var.env}-elb-logs"
+  elb_logs_s3_bucket = lower("${var.elb_logs_bucket_prefix}-${var.namespace}-${var.env}-elb-logs")
 }
 
 data "aws_iam_policy_document" "elb_logs" {


### PR DESCRIPTION
Buckets can only have lowercase letters in the name. Our "namespace" variable needs to have some non-lowercase letters in it. To fix this, I'm making the bucket name itself lowercase.